### PR TITLE
fix: remove superfluous variable managed identity client id

### DIFF
--- a/snakemake_executor_plugin_azure_batch/__init__.py
+++ b/snakemake_executor_plugin_azure_batch/__init__.py
@@ -124,15 +124,6 @@ class ExecutorSettings(ExecutorSettingsBase):
             "env_var": True,
         },
     )
-    managed_identity_client_id: Optional[str] = field(
-        default=None,
-        repr=False,
-        metadata={
-            "help": "Azure Managed Identity client id.",
-            "required": False,
-            "env_var": True,
-        },
-    )
     node_start_task_url: Optional[str] = field(
         default=None,
         metadata={

--- a/snakemake_executor_plugin_azure_batch/build.py
+++ b/snakemake_executor_plugin_azure_batch/build.py
@@ -95,8 +95,7 @@ def batch_pool_params(pool_id: str, settings, container_image: str) -> Pool:
                 "No container registry authentication scheme set. Please set the "
                 "SNAKEMAKE_AZURE_BATCH_CONTAINER_REGISTRY_USER and "
                 "SNAKEMAKE_AZURE_BATCH_CONTAINER_REGISTRY_PASS "
-                "or set SNAKEMAKE_AZURE_BATCH_MANAGED_IDENTITY_CLIENT_ID and "
-                "SNAKEMAKE_AZURE_BATCH_MANAGED_IDENTITY_RESOURCE_ID "
+                "or set SNAKEMAKE_AZURE_BATCH_MANAGED_IDENTITY_RESOURCE_ID "
                 "and Grant it permissions to the Azure Container Registry."
             )
 


### PR DESCRIPTION
This doesn't do anything?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the managed identity client ID configuration field. Users should now configure only the managed identity resource ID for Azure Batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->